### PR TITLE
About-This-Build.txtのワークフローのリビジョンの修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -80,6 +82,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: ilammy/msvc-dev-cmd@v1
         with:


### PR DESCRIPTION
`actions/checkout`で`fetch-depth: 0`の指定をしない場合、正常にrevisionの取得ができなくなるため、追記することで修正を試みました。